### PR TITLE
fix: support npx again with stdin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,15 +1,33 @@
 #!/usr/bin/env node
 
-var fs = require('fs')
-var path = require('path')
-var argv = require('minimist')(process.argv.slice(2));
-var useYarn = require('.')
+var fs = require("fs");
+var path = require("path");
+var argv = require("minimist")(process.argv.slice(2));
+var useYarn = require(".");
 
-var message
+var message;
 if (argv.f) {
-  message = fs.readFileSync(argv.f, 'utf8')
+  message = fs.readFileSync(argv.f, "utf8");
 } else if (argv.m) {
-  message = argv.m
+  message = argv.m;
 }
 
-useYarn(message)
+if (process.stdin.isTTY) {
+  useYarn({ message });
+} else {
+  process.stdin.on("readable", () => {
+    let buffer = "";
+
+    let chunk;
+
+    while ((chunk = process.stdin.read()) != null) {
+      buffer += chunk;
+    }
+
+    if (buffer) {
+      useYarn({ message, npm_execpath: buffer });
+    } else {
+      useYarn({ message });
+    }
+  });
+}

--- a/index.js
+++ b/index.js
@@ -1,13 +1,26 @@
-var isNpmNotYarn = require('is-npm-not-yarn')
-var fs = require('fs')
-var path = require('path')
+var fs = require("fs");
+var path = require("path");
 
-function useYarn(message) {
-  if (isNpmNotYarn && process.env.DISABLE_USE_YARN !== 'true') {
-    message = message || fs.readFileSync(path.resolve(__dirname, 'message.txt'), 'utf8')
-    console.error(message)
-    process.exit(1)
+function useYarn(optionsOrMessage) {
+  const options =
+    // Backwards compatibility since we used to accept only an optional message string
+    typeof optionsOrMessage === "string"
+      ? { message: optionsOrMessage }
+      : optionsOrMessage;
+
+  const npm_execpath = options.npm_execpath || process.env.npm_execpath;
+
+  const isNpmNotYarn = Boolean(npm_execpath) && !/\byarn\b/.test(npm_execpath);
+
+  if (isNpmNotYarn && process.env.DISABLE_USE_YARN !== "true") {
+    const message =
+      options.message ||
+      fs.readFileSync(path.resolve(__dirname, "message.txt"), "utf8");
+
+    console.error(message);
+
+    process.exit(1);
   }
 }
 
-module.exports = useYarn
+module.exports = useYarn;

--- a/index.md
+++ b/index.md
@@ -17,37 +17,41 @@ Note: Use with `>= yarn@1` requires `>= use-yarn@2`.
 ### CLI
 
 For example, in your `package.json`:
+
 ```json
 {
   "scripts": {
-     "preinstall": "use-yarn || ( npm install --save-dev --no-scripts --no-save use-yarn && use-yarn )"
+    "preinstall": "use-yarn || ( npm install --no-scripts --no-save use-yarn && use-yarn )"
   }
 }
 ```
 
-Or if you're on `npm >=5` or have [`npx`][npx]:
+Or if you're on `npm >=5` or have [`npx`][npx], you can run it by passing `$npm_execpath` value in as standard input:
+
 ```json
 {
   "scripts": {
-     "preinstall": "npx use-yarn"
+    "preinstall": "echo $npm_execpath | npx use-yarn"
   }
 }
 ```
 
 You may provide a custom message via the `-m` flag:
+
 ```json
 {
   "scripts": {
-     "preinstall": "npx use-yarn -m 'Please use yarn!'"
+    "preinstall": "echo $npm_execpath | npx use-yarn -m 'Please use yarn!'"
   }
 }
 ```
 
 Or, you may also provide a custom message read from a file via the `-f` flag:
+
 ```json
 {
   "scripts": {
-     "preinstall": "npx use-yarn -f path/to/customMessage.txt"
+    "preinstall": "echo $npm_execpath | npx use-yarn -f path/to/customMessage.txt"
   }
 }
 ```
@@ -57,17 +61,16 @@ You may disable `use-yarn` by setting the `DISABLE_USE_YARN` environment variabl
 ### API
 
 ```js
-var useYarn = require('use-yarn')
+var useYarn = require("use-yarn");
 
-useYarn()
+useYarn();
 
-// or a custom message
-useYarn('You idiot!')
+// or a custom message:
+useYarn({ message: "We like npm!" });
 ```
 
 ## Etc.
 
 If you want to catch missed updates to `yarn.lock` on CI, try [danger-yarn-lock](https://github.com/AndersDJohnson/danger-yarn-lock).
-
 
 [npx]: https://www.npmjs.com/package/npx

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "scripts": {
     "try": "node cli.js",
+    "try-stdin": "echo $npm_execpath | node cli.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": "AndersDJohnson/use-yarn",
   "author": "Anders D. Johnson",
   "license": "ISC",
   "dependencies": {
-    "is-npm-not-yarn": "^2.0.3",
     "minimist": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-is-npm-not-yarn@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-npm-not-yarn/-/is-npm-not-yarn-2.0.3.tgz#d3e64ec49411b199f382ef18c3c9bf976c03c8b0"
-  dependencies:
-    slash "^1.0.0"
-
 minimist@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
-
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"


### PR DESCRIPTION
Hopefully addresses https://github.com/AndersDJohnson/use-yarn/issues/15.

Those using `npx use-yarn` will want to update their `preinstall` scripts as follows:

```diff
-  "preinstall": "npx use-yarn"
+  "preinstall": "echo $npm_execpath | npx use-yarn"
```

The change is intended to be backwards compatible.